### PR TITLE
Remove broken GitHub action for direct build

### DIFF
--- a/.github/workflows/regenerate-pages.yaml
+++ b/.github/workflows/regenerate-pages.yaml
@@ -1,9 +1,9 @@
 name: Regenerate the pages for modules and collections
 
 on: workflow_dispatch
-# on: 
-  # schedule:
-  #   - cron: '0 0 * * * '
+# on:
+# schedule:
+#   - cron: '0 0 * * * '
 
 jobs:
   run:
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: 'npm'
+          cache: "npm"
       - run: npm install
       - name: Run a script to regenerate all information for modules
         run: node ./.github/workflows/regenerate-modules.js
@@ -24,18 +24,20 @@ jobs:
         with:
           default_author: github_actions
           committer_name: ResearchEquals Archiver
-          message: 'Update page templates'
+          message: "Update page templates"
   build_deploy:
     runs-on: ubuntu-latest
     needs: run
     steps:
       - uses: actions/checkout@master
       - name: Build
-        uses: TartanLlama/actions-eleventy@master
+        run: |
+          npm install
+          npm run build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          publish_dir: _site 
+          publish_dir: _site
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
           cname: archive.researchequals.com

--- a/collections/g70r-9s/g70r-9s.md
+++ b/collections/g70r-9s/g70r-9s.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-03-15.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-03-15.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/gcdy-09/gcdy-09.md
+++ b/collections/gcdy-09/gcdy-09.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-02-07.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-02-07.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/hcsy-rf/hcsy-rf.md
+++ b/collections/hcsy-rf/hcsy-rf.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-07-11.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-07-11.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/hqxb-bx/hqxb-bx.md
+++ b/collections/hqxb-bx/hqxb-bx.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-11-09.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-11-09.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/jf14-3a/jf14-3a.md
+++ b/collections/jf14-3a/jf14-3a.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.png" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-10-04.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-10-04.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/kxj5-gs/kxj5-gs.md
+++ b/collections/kxj5-gs/kxj5-gs.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-08-01.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-08-01.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/kye5-v2/kye5-v2.md
+++ b/collections/kye5-v2/kye5-v2.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-02-22.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-02-22.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/kyep-h9/kyep-h9.md
+++ b/collections/kyep-h9/kyep-h9.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-12-14.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-12-14.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/mrhg-9r/mrhg-9r.md
+++ b/collections/mrhg-9r/mrhg-9r.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-05-10.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-05-10.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/na6q-qn/na6q-qn.md
+++ b/collections/na6q-qn/na6q-qn.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-03-02.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-03-02.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/nn7r-n1/nn7r-n1.md
+++ b/collections/nn7r-n1/nn7r-n1.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-03-21.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-03-21.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/p8ec-93/p8ec-93.md
+++ b/collections/p8ec-93/p8ec-93.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-11-18.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-11-18.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/pqq8-j1/pqq8-j1.md
+++ b/collections/pqq8-j1/pqq8-j1.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-01-12.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-01-12.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/ps23-1p/ps23-1p.md
+++ b/collections/ps23-1p/ps23-1p.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-06-06.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-06-06.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/ps2g-kp/ps2g-kp.md
+++ b/collections/ps2g-kp/ps2g-kp.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-06-24.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-06-24.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/psxp-hp/psxp-hp.md
+++ b/collections/psxp-hp/psxp-hp.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.png" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-03-02.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-03-02.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/pvqx-8g/pvqx-8g.md
+++ b/collections/pvqx-8g/pvqx-8g.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-01-26.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-01-26.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/q1gk-30/q1gk-30.md
+++ b/collections/q1gk-30/q1gk-30.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-06-24.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-06-24.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/r01y-0r/r01y-0r.md
+++ b/collections/r01y-0r/r01y-0r.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-06-07.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-06-07.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/rk2x-6j/rk2x-6j.md
+++ b/collections/rk2x-6j/rk2x-6j.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-10-17.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-10-17.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/ry6w-2w/ry6w-2w.md
+++ b/collections/ry6w-2w/ry6w-2w.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-07-27.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-07-27.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/s1hy-bp/s1hy-bp.md
+++ b/collections/s1hy-bp/s1hy-bp.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-05-07.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-05-07.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/t2jh-km/t2jh-km.md
+++ b/collections/t2jh-km/t2jh-km.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-03-02.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-03-02.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/t5xp-wh/t5xp-wh.md
+++ b/collections/t5xp-wh/t5xp-wh.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-11-03.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-11-03.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/tjr8-ew/tjr8-ew.md
+++ b/collections/tjr8-ew/tjr8-ew.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-07-25.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-07-25.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/tm40-yj/tm40-yj.md
+++ b/collections/tm40-yj/tm40-yj.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-02-20.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-02-20.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/vb0q-0y/vb0q-0y.md
+++ b/collections/vb0q-0y/vb0q-0y.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-02-20.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-02-20.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/vh6y-f2/vh6y-f2.md
+++ b/collections/vh6y-f2/vh6y-f2.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-08-26.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-08-26.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/vjdn-6q/vjdn-6q.md
+++ b/collections/vjdn-6q/vjdn-6q.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-11-17.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-11-17.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/vygt-jr/vygt-jr.md
+++ b/collections/vygt-jr/vygt-jr.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-02-23.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-02-23.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/w1yb-gr/w1yb-gr.md
+++ b/collections/w1yb-gr/w1yb-gr.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-10-21.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-10-21.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/w252-em/w252-em.md
+++ b/collections/w252-em/w252-em.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-06-24.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-06-24.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/waca-fd/waca-fd.md
+++ b/collections/waca-fd/waca-fd.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-06-24.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-06-24.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/wcrq-jc/wcrq-jc.md
+++ b/collections/wcrq-jc/wcrq-jc.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-02-20.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-02-20.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/x1cq-69/x1cq-69.md
+++ b/collections/x1cq-69/x1cq-69.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-03-02.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-03-02.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/xpz5-f9/xpz5-f9.md
+++ b/collections/xpz5-f9/xpz5-f9.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-03-08.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-03-08.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/xyns-p3/xyns-p3.md
+++ b/collections/xyns-p3/xyns-p3.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-07-27.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-07-27.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/yqqk-02/yqqk-02.md
+++ b/collections/yqqk-02/yqqk-02.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-07-27.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-07-27.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/yrf3-p1/yrf3-p1.md
+++ b/collections/yrf3-p1/yrf3-p1.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2023-07-27.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2023-07-27.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/ytxf-y6/ytxf-y6.md
+++ b/collections/ytxf-y6/ytxf-y6.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2022-11-18.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2022-11-18.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/z9jy-rk/z9jy-rk.md
+++ b/collections/z9jy-rk/z9jy-rk.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-05-13.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-05-13.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/collections/zw5c-fx/zw5c-fx.md
+++ b/collections/zw5c-fx/zw5c-fx.md
@@ -1,11 +1,11 @@
 ---
-layout: collection.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 {% if subtitle %}
 <div role="doc-subtitle">{{ subtitle }}</div>
 {% endif %}
-        
+    
 {% if type.type == "COMMUNITY" %}
 <img class="header-image" src="header.jpg" />
 {% endif %}
@@ -23,13 +23,13 @@ Last updated on  2024-05-20.
 
 <ul>
 {%- for editor in editors -%}
- <li>
- {% if editor.workspace.orcid %}
- <a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
- {% else %}
- {{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if editor.workspace.orcid %}
+<a href="https://orcid.org/{{ editor.workspace.orcid }}">{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}</a>
+{% else %}
+{{ editor.workspace.firstName }} {{ editor.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -41,16 +41,16 @@ Last updated on  2024-05-20.
 ## Collected works
 <ul>
 {%- for submission in submissions -%}
- {% if submission.accepted %} 
- <li>
- <p>{{ submission.module.title }}</p>
- <p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
- {% if submission.comment and submission.comment != "" %}
- <blockquote>{{ submission.comment }}
- <div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
- {% endif %}
- </li>
- {% endif %}
+{% if submission.accepted %} 
+<li>
+<p>{{ submission.module.title }}</p>
+<p><a href="https://doi.org/{{ submission.module.prefix }}/{{ submission.module.suffix }}">doi: {{ submission.module.prefix }}/{{ submission.module.suffix }}</a></p>
+{% if submission.comment and submission.comment != "" %}
+<blockquote>{{ submission.comment }}
+<div class="quote-footer">—{{ submission.editor.workspace.firstName }} {{ submission.editor.workspace.lastName }}</cite></div class="quote-footer"></blockquote>
+{% endif %}
+</li>
+{% endif %}
 {%- endfor -%}
 </ul>
 {% endif %}

--- a/modules/g096-x0vs/g096-x0vs.md
+++ b/modules/g096-x0vs/g096-x0vs.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/g2r8-ysds/g2r8-ysds.md
+++ b/modules/g2r8-ysds/g2r8-ysds.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-04 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-04 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-04 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/g51e-33cq/g51e-33cq.md
+++ b/modules/g51e-33cq/g51e-33cq.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/g6hr-cn36/g6hr-cn36.md
+++ b/modules/g6hr-cn36/g6hr-cn36.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-05-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-05-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-05-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/g7ew-yhzk/g7ew-yhzk.md
+++ b/modules/g7ew-yhzk/g7ew-yhzk.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/g7sh-1cf0/g7sh-1cf0.md
+++ b/modules/g7sh-1cf0/g7sh-1cf0.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/g9j4-v2gy/g9j4-v2gy.md
+++ b/modules/g9j4-v2gy/g9j4-v2gy.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-09-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-09-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-09-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ga55-chfj/ga55-chfj.md
+++ b/modules/ga55-chfj/ga55-chfj.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-06-17 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-06-17 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-06-17 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ggwk-pv37/ggwk-pv37.md
+++ b/modules/ggwk-pv37/ggwk-pv37.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-04-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-04-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-04-07 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/gjfr-9anm/gjfr-9anm.md
+++ b/modules/gjfr-9anm/gjfr-9anm.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-01-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-01-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-01-18 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/gm7y-31n5/gm7y-31n5.md
+++ b/modules/gm7y-31n5/gm7y-31n5.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-01-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-01-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-01-25 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/gn9z-7hcm/gn9z-7hcm.md
+++ b/modules/gn9z-7hcm/gn9z-7hcm.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/gv7g-cr7g/gv7g-cr7g.md
+++ b/modules/gv7g-cr7g/gv7g-cr7g.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/gvha-0jd8/gvha-0jd8.md
+++ b/modules/gvha-0jd8/gvha-0jd8.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-27 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/gvjz-mbgf/gvjz-mbgf.md
+++ b/modules/gvjz-mbgf/gvjz-mbgf.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/h2qy-qc0e/h2qy-qc0e.md
+++ b/modules/h2qy-qc0e/h2qy-qc0e.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/h3gv-g93x/h3gv-g93x.md
+++ b/modules/h3gv-g93x/h3gv-g93x.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-07-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-07-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-07-12 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/h577-dwq7/h577-dwq7.md
+++ b/modules/h577-dwq7/h577-dwq7.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/h8tj-63at/h8tj-63at.md
+++ b/modules/h8tj-63at/h8tj-63at.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hbfx-kmg3/hbfx-kmg3.md
+++ b/modules/hbfx-kmg3/hbfx-kmg3.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hctz-7mk8/hctz-7mk8.md
+++ b/modules/hctz-7mk8/hctz-7mk8.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hetr-94gh/hetr-94gh.md
+++ b/modules/hetr-94gh/hetr-94gh.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-06 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hhfn-cwbw/hhfn-cwbw.md
+++ b/modules/hhfn-cwbw/hhfn-cwbw.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hhv0-29er/hhv0-29er.md
+++ b/modules/hhv0-29er/hhv0-29er.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-01-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-01-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-01-24 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hkvp-xkx7/hkvp-xkx7.md
+++ b/modules/hkvp-xkx7/hkvp-xkx7.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hn7c-20eb/hn7c-20eb.md
+++ b/modules/hn7c-20eb/hn7c-20eb.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hp86-0esy/hp86-0esy.md
+++ b/modules/hp86-0esy/hp86-0esy.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hprp-rh02/hprp-rh02.md
+++ b/modules/hprp-rh02/hprp-rh02.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-06-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-06-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-06-24 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hqgh-yxx6/hqgh-yxx6.md
+++ b/modules/hqgh-yxx6/hqgh-yxx6.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-14 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hstd-cqpe/hstd-cqpe.md
+++ b/modules/hstd-cqpe/hstd-cqpe.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-11-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-11-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-11-24 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/htgw-mtcn/htgw-mtcn.md
+++ b/modules/htgw-mtcn/htgw-mtcn.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hyf6-hfz7/hyf6-hfz7.md
+++ b/modules/hyf6-hfz7/hyf6-hfz7.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-12-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-12-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-12-12 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/hzk8-8ytf/hzk8-8ytf.md
+++ b/modules/hzk8-8ytf/hzk8-8ytf.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/j2rb-zpk3/j2rb-zpk3.md
+++ b/modules/j2rb-zpk3/j2rb-zpk3.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-28 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/j5fx-4zy8/j5fx-4zy8.md
+++ b/modules/j5fx-4zy8/j5fx-4zy8.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-04 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-04 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-04 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/j9vg-xm2w/j9vg-xm2w.md
+++ b/modules/j9vg-xm2w/j9vg-xm2w.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-01-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-01-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-01-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jcc3-qsaa/jcc3-qsaa.md
+++ b/modules/jcc3-qsaa/jcc3-qsaa.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-08-10 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-08-10 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-08-10 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jcvk-9f4b/jcvk-9f4b.md
+++ b/modules/jcvk-9f4b/jcvk-9f4b.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jdt3-gwgv/jdt3-gwgv.md
+++ b/modules/jdt3-gwgv/jdt3-gwgv.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jjjx-3xqe/jjjx-3xqe.md
+++ b/modules/jjjx-3xqe/jjjx-3xqe.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-08-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-08-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-08-28 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jkf5-0zc7/jkf5-0zc7.md
+++ b/modules/jkf5-0zc7/jkf5-0zc7.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-06-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-06-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-06-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jn77-mprt/jn77-mprt.md
+++ b/modules/jn77-mprt/jn77-mprt.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-24 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jqm7-s9p0/jqm7-s9p0.md
+++ b/modules/jqm7-s9p0/jqm7-s9p0.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-09-16 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-09-16 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-09-16 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jvhv-4yqp/jvhv-4yqp.md
+++ b/modules/jvhv-4yqp/jvhv-4yqp.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-05-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jvw1-ewd5/jvw1-ewd5.md
+++ b/modules/jvw1-ewd5/jvw1-ewd5.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/jyxk-ttb4/jyxk-ttb4.md
+++ b/modules/jyxk-ttb4/jyxk-ttb4.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/k06w-2ket/k06w-2ket.md
+++ b/modules/k06w-2ket/k06w-2ket.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-10-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-10-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-10-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/k1dt-5dbt/k1dt-5dbt.md
+++ b/modules/k1dt-5dbt/k1dt-5dbt.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/k2f0-z7v8/k2f0-z7v8.md
+++ b/modules/k2f0-z7v8/k2f0-z7v8.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/k2m4-2x3h/k2m4-2x3h.md
+++ b/modules/k2m4-2x3h/k2m4-2x3h.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/k5e5-t1dn/k5e5-t1dn.md
+++ b/modules/k5e5-t1dn/k5e5-t1dn.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/k93r-w4zs/k93r-w4zs.md
+++ b/modules/k93r-w4zs/k93r-w4zs.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-12-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-12-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-12-14 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/kg3t-4wkp/kg3t-4wkp.md
+++ b/modules/kg3t-4wkp/kg3t-4wkp.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-28 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/kh4k-185b/kh4k-185b.md
+++ b/modules/kh4k-185b/kh4k-185b.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/kjp9-g898/kjp9-g898.md
+++ b/modules/kjp9-g898/kjp9-g898.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-06-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-06-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-06-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/kk47-wsmx/kk47-wsmx.md
+++ b/modules/kk47-wsmx/kk47-wsmx.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-05-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-05-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-05-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/knm3-bnvx/knm3-bnvx.md
+++ b/modules/knm3-bnvx/knm3-bnvx.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-10-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-10-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-10-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/kpg3-tb37/kpg3-tb37.md
+++ b/modules/kpg3-tb37/kpg3-tb37.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/kr2h-e72q/kr2h-e72q.md
+++ b/modules/kr2h-e72q/kr2h-e72q.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/kr9t-rzak/kr9t-rzak.md
+++ b/modules/kr9t-rzak/kr9t-rzak.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-07-03 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-07-03 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-07-03 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/krmv-p5c5/krmv-p5c5.md
+++ b/modules/krmv-p5c5/krmv-p5c5.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-01-30 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-01-30 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-01-30 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/kw8q-3w6p/kw8q-3w6p.md
+++ b/modules/kw8q-3w6p/kw8q-3w6p.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ky06-6sqg/ky06-6sqg.md
+++ b/modules/ky06-6sqg/ky06-6sqg.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/m95v-7drc/m95v-7drc.md
+++ b/modules/m95v-7drc/m95v-7drc.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-17 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-17 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-17 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/mdkc-f691/mdkc-f691.md
+++ b/modules/mdkc-f691/mdkc-f691.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/meeb-2ktd/meeb-2ktd.md
+++ b/modules/meeb-2ktd/meeb-2ktd.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/mgz4-p202/mgz4-p202.md
+++ b/modules/mgz4-p202/mgz4-p202.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-03-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-03-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-03-06 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/mk2a-yrp3/mk2a-yrp3.md
+++ b/modules/mk2a-yrp3/mk2a-yrp3.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/mn5r-7ekh/mn5r-7ekh.md
+++ b/modules/mn5r-7ekh/mn5r-7ekh.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-08-10 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-08-10 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-08-10 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ms2c-37js/ms2c-37js.md
+++ b/modules/ms2c-37js/ms2c-37js.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-11-17 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-11-17 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-11-17 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ms4e-e4vf/ms4e-e4vf.md
+++ b/modules/ms4e-e4vf/ms4e-e4vf.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-06-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-06-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-06-06 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/msn7-q3jr/msn7-q3jr.md
+++ b/modules/msn7-q3jr/msn7-q3jr.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-27 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/mtzn-xq83/mtzn-xq83.md
+++ b/modules/mtzn-xq83/mtzn-xq83.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-07-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-07-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-07-14 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/mxqe-7jg3/mxqe-7jg3.md
+++ b/modules/mxqe-7jg3/mxqe-7jg3.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/mxv5-1baa/mxv5-1baa.md
+++ b/modules/mxv5-1baa/mxv5-1baa.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/myxr-mnk8/myxr-mnk8.md
+++ b/modules/myxr-mnk8/myxr-mnk8.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/n17w-rb43/n17w-rb43.md
+++ b/modules/n17w-rb43/n17w-rb43.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-03-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-03-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-03-28 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/n19j-272x/n19j-272x.md
+++ b/modules/n19j-272x/n19j-272x.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/n4yk-8tfy/n4yk-8tfy.md
+++ b/modules/n4yk-8tfy/n4yk-8tfy.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/n5e6-n19f/n5e6-n19f.md
+++ b/modules/n5e6-n19f/n5e6-n19f.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/n64e-nnyr/n64e-nnyr.md
+++ b/modules/n64e-nnyr/n64e-nnyr.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/n7ad-80jf/n7ad-80jf.md
+++ b/modules/n7ad-80jf/n7ad-80jf.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/n8ga-bd9t/n8ga-bd9t.md
+++ b/modules/n8ga-bd9t/n8ga-bd9t.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-06-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-06-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-06-18 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/nf48-5kcp/nf48-5kcp.md
+++ b/modules/nf48-5kcp/nf48-5kcp.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/nn3z-9h4d/nn3z-9h4d.md
+++ b/modules/nn3z-9h4d/nn3z-9h4d.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-10-31 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-10-31 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-10-31 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ntxs-nsa2/ntxs-nsa2.md
+++ b/modules/ntxs-nsa2/ntxs-nsa2.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-12-08 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/p09n-kjpj/p09n-kjpj.md
+++ b/modules/p09n-kjpj/p09n-kjpj.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/p2cf-p8d1/p2cf-p8d1.md
+++ b/modules/p2cf-p8d1/p2cf-p8d1.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/p6ya-fvav/p6ya-fvav.md
+++ b/modules/p6ya-fvav/p6ya-fvav.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/p7bw-ffek/p7bw-ffek.md
+++ b/modules/p7bw-ffek/p7bw-ffek.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-01-30 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-01-30 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-01-30 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/p7ec-pxxb/p7ec-pxxb.md
+++ b/modules/p7ec-pxxb/p7ec-pxxb.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-05-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-05-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-05-12 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/pvcz-egyw/pvcz-egyw.md
+++ b/modules/pvcz-egyw/pvcz-egyw.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-10 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-10 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-10 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/pzgw-a32k/pzgw-a32k.md
+++ b/modules/pzgw-a32k/pzgw-a32k.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-05-19 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-05-19 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-05-19 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/q1vn-91e3/q1vn-91e3.md
+++ b/modules/q1vn-91e3/q1vn-91e3.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/q2za-3hkc/q2za-3hkc.md
+++ b/modules/q2za-3hkc/q2za-3hkc.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-08-09 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-08-09 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-08-09 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/q5k9-bsxw/q5k9-bsxw.md
+++ b/modules/q5k9-bsxw/q5k9-bsxw.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/q5mk-t49d/q5mk-t49d.md
+++ b/modules/q5mk-t49d/q5mk-t49d.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/q5n4-a3jp/q5n4-a3jp.md
+++ b/modules/q5n4-a3jp/q5n4-a3jp.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-12 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/q8ws-xchj/q8ws-xchj.md
+++ b/modules/q8ws-xchj/q8ws-xchj.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/q9pb-93wc/q9pb-93wc.md
+++ b/modules/q9pb-93wc/q9pb-93wc.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/q9qd-p4fg/q9qd-p4fg.md
+++ b/modules/q9qd-p4fg/q9qd-p4fg.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qawy-27w4/qawy-27w4.md
+++ b/modules/qawy-27w4/qawy-27w4.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qbwn-ytxd/qbwn-ytxd.md
+++ b/modules/qbwn-ytxd/qbwn-ytxd.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qcwj-d1mp/qcwj-d1mp.md
+++ b/modules/qcwj-d1mp/qcwj-d1mp.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qgrw-dee8/qgrw-dee8.md
+++ b/modules/qgrw-dee8/qgrw-dee8.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qhh2-4yjj/qhh2-4yjj.md
+++ b/modules/qhh2-4yjj/qhh2-4yjj.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qj4h-2j1n/qj4h-2j1n.md
+++ b/modules/qj4h-2j1n/qj4h-2j1n.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-05-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-05-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-05-06 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qm9h-9bea/qm9h-9bea.md
+++ b/modules/qm9h-9bea/qm9h-9bea.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qn8k-yy4b/qn8k-yy4b.md
+++ b/modules/qn8k-yy4b/qn8k-yy4b.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-07 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qnyw-vvcd/qnyw-vvcd.md
+++ b/modules/qnyw-vvcd/qnyw-vvcd.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qpde-b1qe/qpde-b1qe.md
+++ b/modules/qpde-b1qe/qpde-b1qe.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-02-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-02-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-02-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qs20-1xve/qs20-1xve.md
+++ b/modules/qs20-1xve/qs20-1xve.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qv52-3pyk/qv52-3pyk.md
+++ b/modules/qv52-3pyk/qv52-3pyk.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/qyvc-p3ha/qyvc-p3ha.md
+++ b/modules/qyvc-p3ha/qyvc-p3ha.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/r2wc-a78x/r2wc-a78x.md
+++ b/modules/r2wc-a78x/r2wc-a78x.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-07-31 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-07-31 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-07-31 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/r30w-ksmt/r30w-ksmt.md
+++ b/modules/r30w-ksmt/r30w-ksmt.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-07 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/r38d-hjf5/r38d-hjf5.md
+++ b/modules/r38d-hjf5/r38d-hjf5.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-16 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-16 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-16 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/r4qf-7peg/r4qf-7peg.md
+++ b/modules/r4qf-7peg/r4qf-7peg.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/r5gg-jjv0/r5gg-jjv0.md
+++ b/modules/r5gg-jjv0/r5gg-jjv0.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-11-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-11-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-11-28 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/r5rj-vthh/r5rj-vthh.md
+++ b/modules/r5rj-vthh/r5rj-vthh.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ra5p-wq5r/ra5p-wq5r.md
+++ b/modules/ra5p-wq5r/ra5p-wq5r.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-05-17 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-05-17 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-05-17 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rajc-f882/rajc-f882.md
+++ b/modules/rajc-f882/rajc-f882.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rca5-p1p3/rca5-p1p3.md
+++ b/modules/rca5-p1p3/rca5-p1p3.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-24 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-24 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/resg-g417/resg-g417.md
+++ b/modules/resg-g417/resg-g417.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rf8m-9w0b/rf8m-9w0b.md
+++ b/modules/rf8m-9w0b/rf8m-9w0b.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rgh5-8mjf/rgh5-8mjf.md
+++ b/modules/rgh5-8mjf/rgh5-8mjf.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-09-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-09-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-09-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rhqn-fphf/rhqn-fphf.md
+++ b/modules/rhqn-fphf/rhqn-fphf.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rmj5-tra3/rmj5-tra3.md
+++ b/modules/rmj5-tra3/rmj5-tra3.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rq8g-a6kd/rq8g-a6kd.md
+++ b/modules/rq8g-a6kd/rq8g-a6kd.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rqcz-czt4/rqcz-czt4.md
+++ b/modules/rqcz-czt4/rqcz-czt4.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rrvf-fntw/rrvf-fntw.md
+++ b/modules/rrvf-fntw/rrvf-fntw.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rwek-rrny/rwek-rrny.md
+++ b/modules/rwek-rrny/rwek-rrny.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/rx3w-ea1g/rx3w-ea1g.md
+++ b/modules/rx3w-ea1g/rx3w-ea1g.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-23 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-23 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-23 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ryj7-rtqw/ryj7-rtqw.md
+++ b/modules/ryj7-rtqw/ryj7-rtqw.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/s0x3-88n1/s0x3-88n1.md
+++ b/modules/s0x3-88n1/s0x3-88n1.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-01-19 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-01-19 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-01-19 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/s1bk-kr7d/s1bk-kr7d.md
+++ b/modules/s1bk-kr7d/s1bk-kr7d.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/s30z-4t1w/s30z-4t1w.md
+++ b/modules/s30z-4t1w/s30z-4t1w.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-25 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/sk51-zz5r/sk51-zz5r.md
+++ b/modules/sk51-zz5r/sk51-zz5r.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-10-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-10-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-10-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/skdt-f8aq/skdt-f8aq.md
+++ b/modules/skdt-f8aq/skdt-f8aq.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-11 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/spj3-x65f/spj3-x65f.md
+++ b/modules/spj3-x65f/spj3-x65f.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-08-16 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-08-16 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-08-16 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/st00-zyby/st00-zyby.md
+++ b/modules/st00-zyby/st00-zyby.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-11 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/stas-tpcp/stas-tpcp.md
+++ b/modules/stas-tpcp/stas-tpcp.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/sx75-pswh/sx75-pswh.md
+++ b/modules/sx75-pswh/sx75-pswh.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/t2f2-6593/t2f2-6593.md
+++ b/modules/t2f2-6593/t2f2-6593.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tbp2-qxg5/tbp2-qxg5.md
+++ b/modules/tbp2-qxg5/tbp2-qxg5.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-04-09 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-04-09 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-04-09 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tc3y-r8fs/tc3y-r8fs.md
+++ b/modules/tc3y-r8fs/tc3y-r8fs.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tcvv-5q3y/tcvv-5q3y.md
+++ b/modules/tcvv-5q3y/tcvv-5q3y.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-06-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-06-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-06-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/td5x-jt92/td5x-jt92.md
+++ b/modules/td5x-jt92/td5x-jt92.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tf3c-22ec/tf3c-22ec.md
+++ b/modules/tf3c-22ec/tf3c-22ec.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/th9g-sjzj/th9g-sjzj.md
+++ b/modules/th9g-sjzj/th9g-sjzj.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-08-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tkbq-vngk/tkbq-vngk.md
+++ b/modules/tkbq-vngk/tkbq-vngk.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-01-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-01-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-01-11 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tkj9-d4kf/tkj9-d4kf.md
+++ b/modules/tkj9-d4kf/tkj9-d4kf.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tn38-4q91/tn38-4q91.md
+++ b/modules/tn38-4q91/tn38-4q91.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-04-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-04-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-04-07 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tn4n-4hnn/tn4n-4hnn.md
+++ b/modules/tn4n-4hnn/tn4n-4hnn.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tngj-d1ce/tngj-d1ce.md
+++ b/modules/tngj-d1ce/tngj-d1ce.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/tqv8-3raw/tqv8-3raw.md
+++ b/modules/tqv8-3raw/tqv8-3raw.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/v3bg-jhmk/v3bg-jhmk.md
+++ b/modules/v3bg-jhmk/v3bg-jhmk.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-11-30 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-11-30 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-11-30 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/v3gr-nzdb/v3gr-nzdb.md
+++ b/modules/v3gr-nzdb/v3gr-nzdb.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-07 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-07 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/v4pn-g7sx/v4pn-g7sx.md
+++ b/modules/v4pn-g7sx/v4pn-g7sx.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/v6p1-7h9v/v6p1-7h9v.md
+++ b/modules/v6p1-7h9v/v6p1-7h9v.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-01-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-01-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-01-18 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vabx-9xc3/vabx-9xc3.md
+++ b/modules/vabx-9xc3/vabx-9xc3.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-04-23 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-04-23 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-04-23 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vaq3-x2tv/vaq3-x2tv.md
+++ b/modules/vaq3-x2tv/vaq3-x2tv.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-14 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vbzj-8vsq/vbzj-8vsq.md
+++ b/modules/vbzj-8vsq/vbzj-8vsq.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-27 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vhs4-7e23/vhs4-7e23.md
+++ b/modules/vhs4-7e23/vhs4-7e23.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-11-18 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vj97-278g/vj97-278g.md
+++ b/modules/vj97-278g/vj97-278g.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-04-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-04-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-04-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vmna-yhcd/vmna-yhcd.md
+++ b/modules/vmna-yhcd/vmna-yhcd.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vqza-e40g/vqza-e40g.md
+++ b/modules/vqza-e40g/vqza-e40g.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-11 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vrd3-8h76/vrd3-8h76.md
+++ b/modules/vrd3-8h76/vrd3-8h76.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-09-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-09-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-09-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vt4b-p2a9/vt4b-p2a9.md
+++ b/modules/vt4b-p2a9/vt4b-p2a9.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-07-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-07-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-07-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/vygs-x77h/vygs-x77h.md
+++ b/modules/vygs-x77h/vygs-x77h.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-12-08 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/w0d6-9kwa/w0d6-9kwa.md
+++ b/modules/w0d6-9kwa/w0d6-9kwa.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/w0g0-vzmx/w0g0-vzmx.md
+++ b/modules/w0g0-vzmx/w0g0-vzmx.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/w3xc-c2jb/w3xc-c2jb.md
+++ b/modules/w3xc-c2jb/w3xc-c2jb.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/we21-b1ph/we21-b1ph.md
+++ b/modules/we21-b1ph/we21-b1ph.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-16 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-16 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-16 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wh19-z8qr/wh19-z8qr.md
+++ b/modules/wh19-z8qr/wh19-z8qr.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wh45-m9c2/wh45-m9c2.md
+++ b/modules/wh45-m9c2/wh45-m9c2.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-05-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-05-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-05-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wk5w-e1fh/wk5w-e1fh.md
+++ b/modules/wk5w-e1fh/wk5w-e1fh.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wkr0-nn6t/wkr0-nn6t.md
+++ b/modules/wkr0-nn6t/wkr0-nn6t.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-09-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-09-27 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-09-27 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wqdt-w1ke/wqdt-w1ke.md
+++ b/modules/wqdt-w1ke/wqdt-w1ke.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-08-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wr2a-94m4/wr2a-94m4.md
+++ b/modules/wr2a-94m4/wr2a-94m4.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-13 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-13 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wt8e-3sw8/wt8e-3sw8.md
+++ b/modules/wt8e-3sw8/wt8e-3sw8.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-02 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wxef-c5p1/wxef-c5p1.md
+++ b/modules/wxef-c5p1/wxef-c5p1.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-14 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/wz7c-s5wc/wz7c-s5wc.md
+++ b/modules/wz7c-s5wc/wz7c-s5wc.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-08-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-08-12 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-08-12 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/x0mq-3amc/x0mq-3amc.md
+++ b/modules/x0mq-3amc/x0mq-3amc.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/xcqv-xxc6/xcqv-xxc6.md
+++ b/modules/xcqv-xxc6/xcqv-xxc6.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/xfd8-pp0g/xfd8-pp0g.md
+++ b/modules/xfd8-pp0g/xfd8-pp0g.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-07-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-07-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-07-05 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/xk2n-bmcn/xk2n-bmcn.md
+++ b/modules/xk2n-bmcn/xk2n-bmcn.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-03-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-03-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-03-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/xnfg-9kxe/xnfg-9kxe.md
+++ b/modules/xnfg-9kxe/xnfg-9kxe.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-01-04 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-01-04 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-01-04 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/xq9h-ackt/xq9h-ackt.md
+++ b/modules/xq9h-ackt/xq9h-ackt.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-06-05 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/xszd-x8dr/xszd-x8dr.md
+++ b/modules/xszd-x8dr/xszd-x8dr.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-07-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-07-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-07-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/xwm2-j2qx/xwm2-j2qx.md
+++ b/modules/xwm2-j2qx/xwm2-j2qx.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/xx1m-ff5n/xx1m-ff5n.md
+++ b/modules/xx1m-ff5n/xx1m-ff5n.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-06 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/y02x-8k3x/y02x-8k3x.md
+++ b/modules/y02x-8k3x/y02x-8k3x.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-02-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-02-06 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-02-06 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/y3qw-n9a0/y3qw-n9a0.md
+++ b/modules/y3qw-n9a0/y3qw-n9a0.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-01-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-01-25 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-01-25 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/y3xv-js3b/y3xv-js3b.md
+++ b/modules/y3xv-js3b/y3xv-js3b.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-10-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ya64-dagv/ya64-dagv.md
+++ b/modules/ya64-dagv/ya64-dagv.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ydg7-6xep/ydg7-6xep.md
+++ b/modules/ydg7-6xep/ydg7-6xep.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/yfas-8487/yfas-8487.md
+++ b/modules/yfas-8487/yfas-8487.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-12-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-12-28 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-12-28 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/yjqd-5g8m/yjqd-5g8m.md
+++ b/modules/yjqd-5g8m/yjqd-5g8m.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-03-15 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/yp05-5fwc/yp05-5fwc.md
+++ b/modules/yp05-5fwc/yp05-5fwc.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-07-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/yv22-p1b2/yv22-p1b2.md
+++ b/modules/yv22-p1b2/yv22-p1b2.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2024-04-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2024-04-01 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2024-04-01 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/ywda-9ghy/ywda-9ghy.md
+++ b/modules/ywda-9ghy/ywda-9ghy.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-08-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-08-14 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-08-14 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/z20d-ry07/z20d-ry07.md
+++ b/modules/z20d-ry07/z20d-ry07.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-04-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-04-08 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-04-08 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/z2tz-9azg/z2tz-9azg.md
+++ b/modules/z2tz-9azg/z2tz-9azg.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/z783-40a1/z783-40a1.md
+++ b/modules/z783-40a1/z783-40a1.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-07-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-07-21 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-07-21 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/zjyz-td93/zjyz-td93.md
+++ b/modules/zjyz-td93/zjyz-td93.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-02-22 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/zm0c-rjcr/zm0c-rjcr.md
+++ b/modules/zm0c-rjcr/zm0c-rjcr.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2022-06-20 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 

--- a/modules/zrtc-b4dw/zrtc-b4dw.md
+++ b/modules/zrtc-b4dw/zrtc-b4dw.md
@@ -1,5 +1,5 @@
 ---
-layout: module.njk
+layout: mylayout.njk
 ---
 # {{ title }}
 
@@ -11,13 +11,13 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for author in authors -%}
- <li>
- {% if author.workspace.orcid %}
- <a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
- {% else %}
- {{ author.workspace.firstName }} {{ author.workspace.lastName }}
- {% endif %}
- </li>
+<li>
+{% if author.workspace.orcid %}
+<a href="https://orcid.org/{{ author.workspace.orcid }}">{{ author.workspace.firstName }} {{ author.workspace.lastName }}</a>
+{% else %}
+{{ author.workspace.firstName }} {{ author.workspace.lastName }}
+{% endif %}
+</li>
 {%- endfor -%}
 </ul>
 
@@ -34,7 +34,7 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 
 <ul>
 {%- for file in supporting.files -%}
-  <li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
+<li><a href="supporting/{{ file.original_filename }}">{{ file.original_filename }}</a></li>
 {%- endfor -%}
 </ul>
 {% endif %}
@@ -42,10 +42,10 @@ Originally published on 2023-03-26 under a <a href="{{ license.url }}">{{ licens
 {% if references[0] %}
 ## References
 
-<ol>
+<ul>
 {%- for reference in references -%}
-<li>{{ reference.title }}. <a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">doi: {{reference.prefix}}/{{reference.suffix}}</a></li>
+<li><a href="https://doi.org/{{reference.prefix}}/{{reference.suffix}}">{{ reference.title }}</a></li>
 {%- endfor -%}
-</ol>
+</ul>
 {% endif %}
 


### PR DESCRIPTION
The GitHub action `TartanLlama/actions-eleventy` still runs on node 17, which breaks the eleventy builds at the moment.

In essence, the action does not do anything special beyond standardizing how to run the build process from an action. This is scalable, but given that it is broken, it makes sense to replace it with a build process fit for our purposes here.
